### PR TITLE
PXS-581 Move magic numbers & strings into constants file

### DIFF
--- a/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
+++ b/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingSource
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import com.pindex.main.models.ExperienceDto
+import com.pindex.main.utils.Constants
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -13,31 +14,21 @@ class ExperiencePagingSource(
     private val db: FirebaseFirestore
 ) : PagingSource<QuerySnapshot, ExperienceDto>() {
 
-    /**
-     * The experiences collection name in Firestore.
-     */
-    private val FIRESTORE_COLLECTION = "activities"
-
-    /**
-     * The number of documents to fetch per request.
-     */
-    private val QUERY_LIMIT: Long = 10
-
     override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, ExperienceDto> {
         return try {
             // Current chunk of experiences to fetch
-            val currentPage = params.key ?: db.collection(FIRESTORE_COLLECTION)
+            val currentPage = params.key ?: db.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
                     .whereEqualTo("status", "listed")
-                    .limit(QUERY_LIMIT)
+                    .limit(Constants.FIRESTORE_QUERY_LIMIT)
                     .get()
                     .await()
 
             val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
 
             // Next chunk of experiences to fetch
-            val nextPage = db.collection(FIRESTORE_COLLECTION)
+            val nextPage = db.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
                     .whereEqualTo("status", "listed")
-                    .limit(QUERY_LIMIT)
+                    .limit(Constants.FIRESTORE_QUERY_LIMIT)
                     .startAfter(lastDocumentSnapshot)
                     .get()
                     .await()

--- a/app/src/main/java/com/pindex/main/home/ExperienceActivity.kt
+++ b/app/src/main/java/com/pindex/main/home/ExperienceActivity.kt
@@ -8,13 +8,16 @@ import com.pindex.main.R
 import com.pindex.main.models.BlockDto
 import com.pindex.main.models.ExperienceDto
 import com.pindex.main.ui.blocks.*
+import com.pindex.main.utils.Constants
 import com.pindex.main.utils.Converter
 
 class ExperienceActivity : AppCompatActivity() {
 
-    private val MARGIN_X = 60
-
-    private val BORDERLESS_IMAGE_HEIGHT = 250
+    /**
+     * Horizontal margin for this activity content ; declared here
+     * because used multiple times.
+     */
+    private val contentMarginX: Int = Constants.ACTIVITY_EXPERIENCE_CONTENT_MARGIN_X
 
     private lateinit var layout: LinearLayout
 
@@ -24,7 +27,7 @@ class ExperienceActivity : AppCompatActivity() {
 
         layout = findViewById<LinearLayout>(R.id.experience_root_layout)
 
-        val experience: ExperienceDto? = intent.getParcelableExtra("EXPERIENCE")
+        val experience: ExperienceDto? = intent.getParcelableExtra(Constants.ACTIVITY_EXPERIENCE_EXTRA_NAME)
 
         // Get the experience Pindex blocks
         val blocks: ArrayList<BlockDto>? = experience?.content?.get(0)?.blocksWrapper?.blocks
@@ -55,7 +58,7 @@ class ExperienceActivity : AppCompatActivity() {
             sectionTitleBlock.text = block.sectionTitle
 
             // Set the margins
-            params.setMargins(MARGIN_X,0,MARGIN_X,15)
+            params.setMargins(contentMarginX,0,contentMarginX,Constants.BLOCK_SECTION_TITLE_MARGIN_BOTTOM)
             sectionTitleBlock.layoutParams = params
 
             // Add the Section Title widget to the root layout
@@ -65,21 +68,21 @@ class ExperienceActivity : AppCompatActivity() {
         when (block.type) {
             "audio" -> {
                 view = AudioBlock(block.audio?.audioPath, block.audio?.imagePath, block.audio?.name, this)
-                params.setMargins(MARGIN_X,0,MARGIN_X,50)
+                params.setMargins(contentMarginX,0,contentMarginX,Constants.BLOCK_AUDIO_MARGIN_BOTTOM)
             }
             "bigHeader" -> {
                 view = BigHeaderBlock(block.text?.text, this)
-                params.setMargins(MARGIN_X,0,MARGIN_X,50)
+                params.setMargins(contentMarginX,0,contentMarginX,Constants.BLOCK_BIG_HEADER_MARGIN_BOTTOM)
             }
             "borderlessImage" -> {
                 view = BorderlessImageBlock(block.image?.imagePath, this)
                 // Set the image height here in order to display its background colour
-                params.height = Converter.dpToPixels(BORDERLESS_IMAGE_HEIGHT, this)
-                params.setMargins(0,0,0,50)
+                params.height = Converter.dpToPixels(Constants.BLOCK_BORDERLESS_IMAGE_HEIGHT, this)
+                params.setMargins(0,0,0,Constants.BLOCK_BORDERLESS_IMAGE_MARGIN_BOTTOM)
             }
             "text" -> {
                 view = TextBlock(block.text?.text, this)
-                params.setMargins(MARGIN_X,0,MARGIN_X,50)
+                params.setMargins(contentMarginX,0,contentMarginX,Constants.BLOCK_TEXT_MARGIN_BOTTOM)
             }
         }
 

--- a/app/src/main/java/com/pindex/main/home/ExperienceActivity.kt
+++ b/app/src/main/java/com/pindex/main/home/ExperienceActivity.kt
@@ -53,9 +53,7 @@ class ExperienceActivity : AppCompatActivity() {
 
         // Create and add a Section Title when the block has a sectionTitle property
         if (block.sectionTitle != null) {
-            var sectionTitleBlock: SectionTitleBlock = SectionTitleBlock(this)
-
-            sectionTitleBlock.text = block.sectionTitle
+            var sectionTitleBlock: SectionTitleBlock = SectionTitleBlock(block.sectionTitle, this)
 
             // Set the margins
             params.setMargins(contentMarginX,0,contentMarginX,Constants.BLOCK_SECTION_TITLE_MARGIN_BOTTOM)

--- a/app/src/main/java/com/pindex/main/ui/blocks/SectionTitleBlock.kt
+++ b/app/src/main/java/com/pindex/main/ui/blocks/SectionTitleBlock.kt
@@ -10,6 +10,7 @@ import com.pindex.main.R
  * Custom TextView for the Section Title block.
  */
 class SectionTitleBlock @JvmOverloads constructor(
+        title: String?,
         context: Context,
         attrs: AttributeSet? = null,
         defStyle: Int = 0
@@ -19,6 +20,9 @@ class SectionTitleBlock @JvmOverloads constructor(
      * Apply the Section Title block styles to this TextView.
      */
     init {
+        // Set the text
+        text = title
+
         // Font family
         typeface = ResourcesCompat.getFont(context, R.font.montserrat_bold)
 

--- a/app/src/main/java/com/pindex/main/ui/fragments/ExperienceFragment.kt
+++ b/app/src/main/java/com/pindex/main/ui/fragments/ExperienceFragment.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.pindex.main.R
 import com.pindex.main.adapters.ExperienceAdapter
 import com.pindex.main.home.ExperienceActivity
+import com.pindex.main.utils.Constants
 import com.pindex.main.viewmodels.ExperienceViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -49,7 +50,7 @@ class ExperienceFragment : Fragment(R.layout.fragment_experience) {
     private fun setRecyclerViewOnItemClick() {
         adapter.onItemClick = { experience ->
             val intent = Intent(activity, ExperienceActivity::class.java)
-            intent.putExtra("EXPERIENCE", experience)
+            intent.putExtra(Constants.ACTIVITY_EXPERIENCE_EXTRA_NAME, experience)
 
             // Display the clicked experience activity
             startActivity(intent)

--- a/app/src/main/java/com/pindex/main/utils/Constants.kt
+++ b/app/src/main/java/com/pindex/main/utils/Constants.kt
@@ -1,0 +1,62 @@
+package com.pindex.main.utils
+
+/**
+ * Singleton that provides constants.
+ */
+object Constants {
+
+    /**
+     * The horizontal margin value for the experience activity content.
+     */
+    const val ACTIVITY_EXPERIENCE_CONTENT_MARGIN_X: Int = 60
+
+    /**
+     * The experience activity extra name to pass data.
+     */
+    const val ACTIVITY_EXPERIENCE_EXTRA_NAME: String = "EXTRA_EXPERIENCE"
+
+    /**
+     * The Audio block margin bottom.
+     */
+    const val BLOCK_AUDIO_MARGIN_BOTTOM: Int = 50
+
+    /**
+     * The Big Header block margin bottom.
+     */
+    const val BLOCK_BIG_HEADER_MARGIN_BOTTOM: Int = 50
+
+    /**
+     * The Borderless Image block height value (in px).
+     */
+    const val BLOCK_BORDERLESS_IMAGE_HEIGHT: Int = 250
+
+    /**
+     * The Borderless Image block margin bottom.
+     */
+    const val BLOCK_BORDERLESS_IMAGE_MARGIN_BOTTOM: Int = 50
+
+    /**
+     * The Text block margin bottom.
+     */
+    const val BLOCK_TEXT_MARGIN_BOTTOM: Int = 50
+
+    /**
+     * The Section Title block margin bottom.
+     */
+    const val BLOCK_SECTION_TITLE_MARGIN_BOTTOM: Int = 15
+
+    /**
+     * The experiences collection name in Firestore.
+     */
+    const val FIRESTORE_EXPERIENCES_COLLECTION: String = "activities"
+
+    /**
+     * Firestore page size value (ViewModel).
+     */
+    const val FIRESTORE_PAGE_SIZE: Int = 10
+
+    /**
+     * The number of documents to fetch per request from Firestore.
+     */
+    const val FIRESTORE_QUERY_LIMIT: Long = 10
+}

--- a/app/src/main/java/com/pindex/main/utils/Constants.kt
+++ b/app/src/main/java/com/pindex/main/utils/Constants.kt
@@ -36,14 +36,14 @@ object Constants {
     const val BLOCK_BORDERLESS_IMAGE_MARGIN_BOTTOM: Int = 50
 
     /**
-     * The Text block margin bottom.
-     */
-    const val BLOCK_TEXT_MARGIN_BOTTOM: Int = 50
-
-    /**
      * The Section Title block margin bottom.
      */
     const val BLOCK_SECTION_TITLE_MARGIN_BOTTOM: Int = 15
+
+    /**
+     * The Text block margin bottom.
+     */
+    const val BLOCK_TEXT_MARGIN_BOTTOM: Int = 50
 
     /**
      * The experiences collection name in Firestore.

--- a/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
+++ b/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
@@ -7,10 +7,11 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.google.firebase.firestore.FirebaseFirestore
 import com.pindex.main.data.ExperiencePagingSource
+import com.pindex.main.utils.Constants
 
 class ExperienceViewModel : ViewModel() {
 
-    val flow = Pager(PagingConfig(10)) {
+    val flow = Pager(PagingConfig(Constants.FIRESTORE_PAGE_SIZE)) {
         ExperiencePagingSource(FirebaseFirestore.getInstance())
     }.flow.cachedIn(viewModelScope)
 


### PR DESCRIPTION
Create a singleton that contains some constants to avoid magic numbers and strings in the code ; a resource file should be used when there is the need to set different values for different cases, like translations or device resolutions.

There are still some magic numbers in the Pindex Blocks classes: they will be refactored in PXS-584.

This PR also refactors the `SectionTitle` block, as it was forgotten in another PR.