### PR TITLE
PXS-597 Implement repository service pattern for experiences

### DIFF
--- a/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
+++ b/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
@@ -14,10 +14,10 @@ class ExperiencePagingSource(private val service: ExperienceService) : PagingSou
     override suspend fun load(params: LoadParams<List<ExperienceDto>>): LoadResult<List<ExperienceDto>, ExperienceDto> {
         return try {
             // If no key is passed, get the first chunk of data
-            val currentPage = params.key ?: service.getPage(Constants.FIRESTORE_QUERY_LIMIT)
+            val currentPage = params.key ?: service.getPage(Constants.EXPERIENCES_REPOSITORY_PAGE_SIZE)
 
             // Next chunk of data
-            val nextPage = service.getPage(Constants.FIRESTORE_QUERY_LIMIT)
+            val nextPage = service.getPage(Constants.EXPERIENCES_REPOSITORY_PAGE_SIZE)
 
             LoadResult.Page(
                 data = currentPage,

--- a/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
+++ b/app/src/main/java/com/pindex/main/data/ExperiencePagingSource.kt
@@ -1,40 +1,26 @@
 package com.pindex.main.data
 
 import androidx.paging.PagingSource
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
 import com.pindex.main.models.ExperienceDto
+import com.pindex.main.services.ExperienceService
 import com.pindex.main.utils.Constants
-import kotlinx.coroutines.tasks.await
 
 /**
- * Fetch the experiences from Firestore by chunk.
+ * Paging Source for the Pindex experiences. This class needs an
+ * ExperienceService in order to get the paginated data.
  */
-class ExperiencePagingSource(
-    private val db: FirebaseFirestore
-) : PagingSource<QuerySnapshot, ExperienceDto>() {
+class ExperiencePagingSource(private val service: ExperienceService) : PagingSource<List<ExperienceDto>, ExperienceDto>() {
 
-    override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, ExperienceDto> {
+    override suspend fun load(params: LoadParams<List<ExperienceDto>>): LoadResult<List<ExperienceDto>, ExperienceDto> {
         return try {
-            // Current chunk of experiences to fetch
-            val currentPage = params.key ?: db.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
-                    .whereEqualTo("status", "listed")
-                    .limit(Constants.FIRESTORE_QUERY_LIMIT)
-                    .get()
-                    .await()
+            // If no key is passed, get the first chunk of data
+            val currentPage = params.key ?: service.getPage(Constants.FIRESTORE_QUERY_LIMIT)
 
-            val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
-
-            // Next chunk of experiences to fetch
-            val nextPage = db.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
-                    .whereEqualTo("status", "listed")
-                    .limit(Constants.FIRESTORE_QUERY_LIMIT)
-                    .startAfter(lastDocumentSnapshot)
-                    .get()
-                    .await()
+            // Next chunk of data
+            val nextPage = service.getPage(Constants.FIRESTORE_QUERY_LIMIT)
 
             LoadResult.Page(
-                data = currentPage.toObjects(ExperienceDto::class.java),
+                data = currentPage,
                 prevKey = null,
                 nextKey = nextPage
             )

--- a/app/src/main/java/com/pindex/main/models/ExperienceDto.kt
+++ b/app/src/main/java/com/pindex/main/models/ExperienceDto.kt
@@ -1,9 +1,8 @@
 package com.pindex.main.models
 
-import com.google.firebase.Timestamp
 import android.os.Parcelable
+import com.google.firebase.Timestamp
 import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
 
 /**
  * An experience can either be a Pindex Tour or a Pindex Activity/Event.

--- a/app/src/main/java/com/pindex/main/repositories/ExperienceRepository.kt
+++ b/app/src/main/java/com/pindex/main/repositories/ExperienceRepository.kt
@@ -1,0 +1,13 @@
+package com.pindex.main.repositories
+
+import com.pindex.main.models.ExperienceDto
+
+interface ExperienceRepository {
+
+    suspend fun getAll(): List<ExperienceDto>
+
+    suspend fun getPage(lastExperience: ExperienceDto? = null): List<ExperienceDto>
+
+    fun getById(id: String): ExperienceDto
+
+}

--- a/app/src/main/java/com/pindex/main/repositories/ExperienceRepository.kt
+++ b/app/src/main/java/com/pindex/main/repositories/ExperienceRepository.kt
@@ -2,12 +2,15 @@ package com.pindex.main.repositories
 
 import com.pindex.main.models.ExperienceDto
 
+/**
+ * Experience repository interface.
+ */
 interface ExperienceRepository {
 
-    suspend fun getAll(): List<ExperienceDto>
-
-    suspend fun getPage(lastExperience: ExperienceDto? = null): List<ExperienceDto>
-
-    fun getById(id: String): ExperienceDto
+    /**
+     * Return a list of ExperienceDto whose size is defined
+     * by the given [limit].
+     */
+    suspend fun getPage(limit: Long): List<ExperienceDto>
 
 }

--- a/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
+++ b/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
@@ -1,91 +1,39 @@
 package com.pindex.main.repositories
 
-import android.util.Log
-import androidx.paging.PagingSource
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
-import com.google.firebase.firestore.ktx.toObject
 import com.pindex.main.models.ExperienceDto
 import com.pindex.main.utils.Constants
 import kotlinx.coroutines.tasks.await
-import java.lang.Exception
-import kotlin.math.exp
 
-class FirebaseExperienceRepository : /*ExperienceRepository,*/
-    PagingSource<ExperienceDto, ExperienceDto>() {
-
-    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
-/*
-    override suspend fun getAll(): List<ExperienceDto> {
-        return firestore.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
-            .get()
-            .await()
-            .toObjects(ExperienceDto::class.java)
-    }
-
+/**
+ * Experience repository that fetches the data from Firestore.
  */
-    /*
-    suspend fun getPage(lastExperience: ExperienceDto?): ExperienceDto {
-        var currentPage = firestore.collection((Constants.FIRESTORE_EXPERIENCES_COLLECTION))
-            .whereEqualTo("status", "listed")
-            .limit(Constants.FIRESTORE_QUERY_LIMIT)
+class FirebaseExperienceRepository : ExperienceRepository {
 
-        lastExperience?.let {
-            currentPage = currentPage.startAfter(lastExperience)
-        }
+    // Firestore instance
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
 
-        return currentPage.get()
-            //.await()
-            //.toObjects(ExperienceDto::class.java)
-    }
+    // Last experience used to fetch the next chunk of data
+    private var lastDocumentSnapshot: DocumentSnapshot? = null
 
-     */
-
-    /*
-    override fun getById(id: String): ExperienceDto {
-        TODO("Not yet implemented")
-    }
-
-     */
-
-    fun getPage(): List<ExperienceDto> {
-        val experiences = ArrayList<ExperienceDto>()
-
-        firestore.collection((Constants.FIRESTORE_EXPERIENCES_COLLECTION))
+    override suspend fun getPage(limit: Long): List<ExperienceDto> {
+        var query = firestore.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
                 .whereEqualTo("status", "listed")
-                .limit(Constants.FIRESTORE_QUERY_LIMIT)
-                .get()
-                .addOnCompleteListener { task ->
-                    if (task.isSuccessful) {
-                        for (document in task.result!!) {
-                            experiences.add(document.toObject(ExperienceDto::class.java))
-                            Log.d("BIBOU", document.toString())
-                        }
 
-                        Log.d("BIBOU", experiences.size.toString())
-
-                    }
-                }
-
-        return experiences
-    }
-
-    override suspend fun load(params: LoadParams<ExperienceDto>): LoadResult<ExperienceDto, ExperienceDto> {
-        return try {
-            val currentPage = getPage()
-
-            val nextPage = currentPage[currentPage.lastIndex]
-
-            LoadResult.Page(
-                data = currentPage,
-                prevKey = null,
-                nextKey = nextPage,
-            )
-        } catch (e: Exception) {
-            LoadResult.Error(e)
+        // Fetch the next chunk of data from the last experience
+        lastDocumentSnapshot?.let {
+            query = query.startAfter(it)
         }
 
-    }
+        val result = query
+                .limit(limit)
+                .get()
+                .await()
 
+        // Update the last experience
+        lastDocumentSnapshot = result.documents[result.size() - 1]
+
+        return result.toObjects(ExperienceDto::class.java)
+    }
 }

--- a/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
+++ b/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
@@ -1,0 +1,91 @@
+package com.pindex.main.repositories
+
+import android.util.Log
+import androidx.paging.PagingSource
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.ktx.toObject
+import com.pindex.main.models.ExperienceDto
+import com.pindex.main.utils.Constants
+import kotlinx.coroutines.tasks.await
+import java.lang.Exception
+import kotlin.math.exp
+
+class FirebaseExperienceRepository : /*ExperienceRepository,*/
+    PagingSource<ExperienceDto, ExperienceDto>() {
+
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
+/*
+    override suspend fun getAll(): List<ExperienceDto> {
+        return firestore.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
+            .get()
+            .await()
+            .toObjects(ExperienceDto::class.java)
+    }
+
+ */
+    /*
+    suspend fun getPage(lastExperience: ExperienceDto?): ExperienceDto {
+        var currentPage = firestore.collection((Constants.FIRESTORE_EXPERIENCES_COLLECTION))
+            .whereEqualTo("status", "listed")
+            .limit(Constants.FIRESTORE_QUERY_LIMIT)
+
+        lastExperience?.let {
+            currentPage = currentPage.startAfter(lastExperience)
+        }
+
+        return currentPage.get()
+            //.await()
+            //.toObjects(ExperienceDto::class.java)
+    }
+
+     */
+
+    /*
+    override fun getById(id: String): ExperienceDto {
+        TODO("Not yet implemented")
+    }
+
+     */
+
+    fun getPage(): List<ExperienceDto> {
+        val experiences = ArrayList<ExperienceDto>()
+
+        firestore.collection((Constants.FIRESTORE_EXPERIENCES_COLLECTION))
+                .whereEqualTo("status", "listed")
+                .limit(Constants.FIRESTORE_QUERY_LIMIT)
+                .get()
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        for (document in task.result!!) {
+                            experiences.add(document.toObject(ExperienceDto::class.java))
+                            Log.d("BIBOU", document.toString())
+                        }
+
+                        Log.d("BIBOU", experiences.size.toString())
+
+                    }
+                }
+
+        return experiences
+    }
+
+    override suspend fun load(params: LoadParams<ExperienceDto>): LoadResult<ExperienceDto, ExperienceDto> {
+        return try {
+            val currentPage = getPage()
+
+            val nextPage = currentPage[currentPage.lastIndex]
+
+            LoadResult.Page(
+                data = currentPage,
+                prevKey = null,
+                nextKey = nextPage,
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
+++ b/app/src/main/java/com/pindex/main/repositories/FirebaseExperienceRepository.kt
@@ -3,13 +3,21 @@ package com.pindex.main.repositories
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.pindex.main.models.ExperienceDto
-import com.pindex.main.utils.Constants
 import kotlinx.coroutines.tasks.await
 
 /**
  * Experience repository that fetches the data from Firestore.
  */
 class FirebaseExperienceRepository : ExperienceRepository {
+
+     // The experiences collection name in Firestore
+    private val experiencesCollection: String = "activities"
+
+    // Used in query
+    private val queryStatus: String = "status"
+
+    // Used in query
+    private val queryStatusListed: String = "listed"
 
     // Firestore instance
     private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
@@ -18,8 +26,8 @@ class FirebaseExperienceRepository : ExperienceRepository {
     private var lastDocumentSnapshot: DocumentSnapshot? = null
 
     override suspend fun getPage(limit: Long): List<ExperienceDto> {
-        var query = firestore.collection(Constants.FIRESTORE_EXPERIENCES_COLLECTION)
-                .whereEqualTo("status", "listed")
+        var query = firestore.collection(experiencesCollection)
+                .whereEqualTo(queryStatus, queryStatusListed)
 
         // Fetch the next chunk of data from the last experience
         lastDocumentSnapshot?.let {

--- a/app/src/main/java/com/pindex/main/services/ExperienceService.kt
+++ b/app/src/main/java/com/pindex/main/services/ExperienceService.kt
@@ -1,0 +1,20 @@
+package com.pindex.main.services
+
+import com.pindex.main.models.ExperienceDto
+import com.pindex.main.repositories.ExperienceRepository
+
+/**
+ * Experience Service for the Pindex experiences. This class needs
+ * a repository in order to get the paginated data.
+ */
+class ExperienceService(private val repository: ExperienceRepository) {
+
+    /**
+     * Use the repository to get the next chunk of data, limited by the
+     * given [limit]. The repository handles the pagination keys.
+     */
+    suspend fun getPage(limit: Long): List<ExperienceDto> {
+        return repository.getPage(limit)
+    }
+
+}

--- a/app/src/main/java/com/pindex/main/utils/Constants.kt
+++ b/app/src/main/java/com/pindex/main/utils/Constants.kt
@@ -80,17 +80,8 @@ object Constants {
     }
 
     /**
-     * The experiences collection name in Firestore.
+     * Number of experiences to fetch per request.
      */
-    const val FIRESTORE_EXPERIENCES_COLLECTION: String = "activities"
+    const val EXPERIENCES_REPOSITORY_PAGE_SIZE: Long = 10
 
-    /**
-     * Firestore page size value (ViewModel).
-     */
-    const val FIRESTORE_PAGE_SIZE: Int = 10
-
-    /**
-     * The number of documents to fetch per request from Firestore.
-     */
-    const val FIRESTORE_QUERY_LIMIT: Long = 10
 }

--- a/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
+++ b/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
@@ -7,12 +7,14 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.google.firebase.firestore.FirebaseFirestore
 import com.pindex.main.data.ExperiencePagingSource
+import com.pindex.main.repositories.FirebaseExperienceRepository
 import com.pindex.main.utils.Constants
 
 class ExperienceViewModel : ViewModel() {
 
     val flow = Pager(PagingConfig(Constants.FIRESTORE_PAGE_SIZE)) {
-        ExperiencePagingSource(FirebaseFirestore.getInstance())
+        //ExperiencePagingSource(FirebaseFirestore.getInstance())
+        FirebaseExperienceRepository()
     }.flow.cachedIn(viewModelScope)
 
 }

--- a/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
+++ b/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
@@ -15,7 +15,7 @@ import com.pindex.main.utils.Constants
  */
 class ExperienceViewModel : ViewModel() {
 
-    val flow = Pager(PagingConfig(Constants.FIRESTORE_PAGE_SIZE)) {
+    val flow = Pager(PagingConfig(Constants.EXPERIENCES_REPOSITORY_PAGE_SIZE.toInt())) {
         ExperiencePagingSource(ExperienceService(FirebaseExperienceRepository()))
     }.flow.cachedIn(viewModelScope)
 

--- a/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
+++ b/app/src/main/java/com/pindex/main/viewmodels/ExperienceViewModel.kt
@@ -5,16 +5,18 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
-import com.google.firebase.firestore.FirebaseFirestore
 import com.pindex.main.data.ExperiencePagingSource
 import com.pindex.main.repositories.FirebaseExperienceRepository
+import com.pindex.main.services.ExperienceService
 import com.pindex.main.utils.Constants
 
+/**
+ * Experience view model that gets the data from a Pager.
+ */
 class ExperienceViewModel : ViewModel() {
 
     val flow = Pager(PagingConfig(Constants.FIRESTORE_PAGE_SIZE)) {
-        //ExperiencePagingSource(FirebaseFirestore.getInstance())
-        FirebaseExperienceRepository()
+        ExperiencePagingSource(ExperienceService(FirebaseExperienceRepository()))
     }.flow.cachedIn(viewModelScope)
 
 }


### PR DESCRIPTION
The `Pager` object of the `ExperienceViewModel` now uses an `ExperienceService` and an `ExperienceRepository` ; it will simplify the test (Firestore mock) and we will also be able to easily change to another repository if needed in the future.